### PR TITLE
made required leaflet geocoder version number generous

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "echo \"No tests\" && exit 0"
   },
   "dependencies": {
-    "leaflet-geocoder-mapzen": "1.6.1",
+    "leaflet-geocoder-mapzen": "^1.6.1",
     "leaflet.locatecontrol": "0.52.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "echo \"No tests\" && exit 0"
   },
   "dependencies": {
-    "leaflet-geocoder-mapzen": "^1.6.1",
+    "leaflet-geocoder-mapzen": "1.7.1",
     "leaflet.locatecontrol": "0.52.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Leaflet geocoder mapzen 1.6.1 seem to have peer dependency of leaflet@^0.7.x || 1.0.0-rc.1 made required version number  more generous